### PR TITLE
Update the code to support the following cases.

### DIFF
--- a/lib/disk.js
+++ b/lib/disk.js
@@ -7,8 +7,8 @@ switch(process.env.platform) {
         module.exports = function(statEmitter, options) {
             let df = "df -Pkl | grep -v Capacity | awk '{ print $1\" \"$2\" \"$3\" \"$4\" \"$5\" \"$6\" \"$7}'";
             exec(df, {stdio:['inherit','pipe','pipe']}, function(err, output, code) {
-                if(err) return;
-
+                if(err) throw err;
+                
                 let drives = output.split('\n');
                 drives.forEach(function(drive) {
                     let drivedetails = drive.split(' ');
@@ -42,17 +42,17 @@ switch(process.env.platform) {
         module.exports = function(statEmitter, options) {
             let wmic = 'wmic LOGICALDISK GET Name, Size, FreeSpace /value | findstr "FreeSpace Name Size"';
             exec(wmic, function(err, output, code) {
-                if(err) return;
+                if(err) throw err;
                 
                 let segments = output.split('\n');
                 for(let i=0; i<segments.length; ++i) {
                     if(segments[i].includes('FreeSpace')) {
                         let free = segments[i].split('=')[1].split('\r\r')[0];
-                        if(!free) return;
+                        if(!free) continue;
                         
                         free = parseInt(free);
                         let filesystem = segments[i+1].split('=')[1].split('\r\r')[0];
-                        if(options.diskfilesystems && options.diskfilesystems.indexOf(filesystem) < 0) return;
+                        if(options.diskfilesystems && options.diskfilesystems.indexOf(filesystem) < 0) continue;
                         
                         let total = parseInt(segments[i+2].split('=')[1].split('\r\r')[0]);
                         let usedpct = Number(parseFloat((total - free) / total * 100).toFixed(2));


### PR DESCRIPTION
- Support the case that there is Drive A: on the machine (no free).
- Throw the error when it happens.
- Continue the next drive in the case that user specify the second drive instead of return immediately